### PR TITLE
issue(chs-to-cht): 令向百度翻译的服务请求频率可配置

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ var chsToChtOptions = {
 if (process.argv[2] && process.argv[2] === 'chs-to-cht') {
   chsToChtOptions.all = params.a || params.all
   chsToChtOptions.force = params.f || params.force
+  chsToChtOptions.queriesPerSecond = params.queriesPerSecond
 }
 
 if (params.y || params.exec) {


### PR DESCRIPTION
百度翻译服务在有些时候有可能遇到频率接受度极低的情况，我自己在
2019/8/6 晚上遇到的情况，甚至一秒钟一个请求都会遇到不少 54003 报错（频
率过高）。这里我们提供了 `--queriesPerSecond` 可选选项，让用户能指定一
个较低（如 1；另外，支持小数，如 0.6）或较高（如 10）来限制请求的频率。